### PR TITLE
Fix #11

### DIFF
--- a/src/SaleorAuthClient.ts
+++ b/src/SaleorAuthClient.ts
@@ -83,7 +83,7 @@ export class SaleorAuthClient {
     invariant(refreshToken, "Missing refresh token in token refresh handler");
 
     // the refresh already finished, proceed as normal
-    if (this.accessToken) {
+    if (this.accessToken && !isExpiredToken(this.accessToken)) {
       return this.fetchWithAuth(input, init);
     }
 


### PR DESCRIPTION
Since `handleRequestWithTokenRefresh` is being called by `fetchWithAuth` and `fetchWithAuth` calls it when the current access token is expired too then `handleRequestWithTokenRefresh` also needs to validate expiry of the access token as otherwise it will just keep looping until a call stack size error occurs.